### PR TITLE
Global config

### DIFF
--- a/pyveda/config.py
+++ b/pyveda/config.py
@@ -1,10 +1,42 @@
 import os
-import sys
+from pyveda.auth import Auth
 
-_PROD = "https://veda-api.geobigdata.io"
-_DEV = "https://veda-api-development.geobigdata.io"
+PROD = "https://veda-api.geobigdata.io"
+DEV = "https://veda-api-development.geobigdata.io"
+LOCAL = "http://host.docker.internal:3002"
 
-HOST = os.environ.et('SANDMAN_API', "https://veda-api.geobigdata.io")
+class _Config:
+    def __init__(self, defhost=PROD):
+        self._HOST = os.environ.get("SANDMAN_API", defhost)
+
+    @property
+    def HOST(self):
+        return self._HOST
 
 
+config = _Config()
 
+def set_prod():
+    config._HOST = PROD
+
+def set_dev():
+    config._HOST = DEV
+
+def set_local():
+    config._HOST = LOCAL
+
+def set_host(host):
+    config._HOST = host
+
+
+class VedaConfig:
+    def __init__(self, conn=Auth().gbdx_connection):
+        self._conn = conn
+
+    @property
+    def host(self):
+        return config.HOST
+
+    @property
+    def conn(self):
+        return self._conn

--- a/pyveda/main.py
+++ b/pyveda/main.py
@@ -191,7 +191,7 @@ def create_from_geojson(geojson, image, name, tilesize=[256,256], match="INTERSE
                               dtype=None, description='',
                               mltype="classification", public=False,
                               partition=[100,0,0], mask=None,
-                              url="{}/data".format(cfg.HOST), **kwargs):
+                              url="{}/data".format(cfg.host), **kwargs):
     """ Loads geojson and an image into a new collection of data
 
     Args:

--- a/pyveda/main.py
+++ b/pyveda/main.py
@@ -1,16 +1,14 @@
 import os
 from contextlib import contextmanager
 
+from pyveda.config import VedaConfig
 from pyveda.exceptions import RemoteCollectionNotFound
-from pyveda.auth import Auth
 from pyveda.vedaset import VedaBase, VedaStream
 from pyveda.veda.loaders import from_geo, from_tarball
 from pyveda.fetch.compat import build_vedabase
 from pyveda.veda.api import _bec, VedaCollectionProxy
 
-gbdx = Auth()
-HOST = os.environ.get('SANDMAN_API', "https://veda-api.geobigdata.io")
-conn = gbdx.gbdx_connection
+cfg = VedaConfig()
 
 __all__ = ["search",
            "open",
@@ -41,7 +39,7 @@ def _map_contains_submap(mmap, submap, hard_match=True):
     return all([mmap[key] == submap[key] for key in shared])
 
 
-def search(params={}, host=HOST, filters={}, **kwargs):
+def search(params={}, filters={}, **kwargs):
     ''' Search Veda for collections
 
     Args:
@@ -52,13 +50,13 @@ def search(params={}, host=HOST, filters={}, **kwargs):
     Returns:
         list: VedaCollectionProxies for collections returned by the search
     '''
-    r = conn.post('{}/{}'.format(host, "search"), json=params)
+    r = cfg.conn.post('{}/{}'.format(host, "search"), json=params)
     r.raise_for_status()
     results = r.json()
     return [VedaCollectionProxy.from_doc(s) for s in results
             if _map_contains_submap(s["properties"], filters, **kwargs)]
 
-def from_id(dataset_id, conn=conn, host=HOST):
+def from_id(dataset_id):
     ''' Returns the dataset as a VedaCollectionProxy from an ID if it exists.
 
     Args:
@@ -70,7 +68,7 @@ def from_id(dataset_id, conn=conn, host=HOST):
         VedaCollectionProxy: the dataset
     '''
 
-    r = conn.get(_bec._dataset_base_furl.format(host_url=host,
+    r = cfg.conn.get(_bec._dataset_base_furl.format(host_url=host,
                                                 dataset_id=dataset_id))
     r.raise_for_status()
     if r.status_code == 200:
@@ -78,7 +76,7 @@ def from_id(dataset_id, conn=conn, host=HOST):
     else:
         raise Exception('Invalid dataset id, does not exist in the database.')
 
-def from_name(dataset_name, conn=conn, host=HOST):
+def from_name(dataset_name):
         ''' Returns the dataset as a VedaCollectionProxy from a name if it exists.
 
         Args:
@@ -157,7 +155,7 @@ def store(filename, dataset_id=None, dataset_name=None, count=None,
     if count is None:
         count = coll.count
     urlgen = coll.gen_sample_ids(count=count)
-    token = gbdx.gbdx_connection.access_token
+    token = cfg.conn.access_token
     build_vedabase(vb, urlgen, partition, count, token,
                        label_threads=1, image_threads=10, **kwargs)
     vb.flush()
@@ -193,7 +191,7 @@ def create_from_geojson(geojson, image, name, tilesize=[256,256], match="INTERSE
                               dtype=None, description='',
                               mltype="classification", public=False,
                               partition=[100,0,0], mask=None,
-                              url="{}/data".format(HOST), conn=conn, **kwargs):
+                              url="{}/data".format(cfg.HOST), **kwargs):
     """ Loads geojson and an image into a new collection of data
 
     Args:
@@ -230,7 +228,7 @@ def create_from_geojson(geojson, image, name, tilesize=[256,256], match="INTERSE
                    dtype=dtype, description=description,
                    mltype=mltype, public=public, sensors=sensors,
                    partition=partition, mask=mask,
-                   url=url, conn=conn, **kwargs)
+                   url=url, **kwargs)
     return VedaCollectionProxy.from_doc(doc)
 
 create_from_tarball = from_tarball

--- a/pyveda/veda/api.py
+++ b/pyveda/veda/api.py
@@ -125,7 +125,6 @@ class DataSampleClient(BaseClient):
         """
         r = self.conn.delete(self._url)
         r.raise_for_status()
-        return None
 
     def __repr__(self):
         data = self.data.copy()
@@ -319,7 +318,6 @@ class VedaCollectionProxy(_VedaCollectionProxy):
             raise VedaUploadError("Cannot load while server-side caching active")
         params = dict(self.meta, url=self._base_url, conn=self.conn, sensors=self.sensors, **kwargs)
         doc = from_geo(geojson, image, **params)
-        return self
 
     def append_from_tarball(self, s3path, **kwargs):
         """

--- a/pyveda/veda/api.py
+++ b/pyveda/veda/api.py
@@ -374,7 +374,7 @@ class VedaCollectionProxy(_VedaCollectionProxy):
     @classmethod
     def from_id(cls, _id):
         """ Helper method that fetches an id into a VedaCollection """
-        r = conn.get("{}/data/{}".format(self.host, _id))
+        r = self.conn.get("{}/data/{}".format(self.host, _id))
         r.raise_for_status()
         doc = r.json()
         doc['properties']['host'] = host

--- a/pyveda/veda/loaders.py
+++ b/pyveda/veda/loaders.py
@@ -38,7 +38,7 @@ def from_tarball(s3path, name=None, dtype='uint8',
                                     public=False,
                                     sensors=[],
                                     partition=[100,0,0],
-                                    url="{}/data/bulk".format(cfg.HOST)):
+                                    url="{}/data/bulk".format(cfg.host)):
     dtype = np.dtype(dtype)
     meta = args_to_meta(name, description, dtype, imshape, mltype, partition, public, sensors)
     options = {
@@ -60,7 +60,7 @@ def from_geo(geojson, image, name=None, tilesize=[256,256], match="INTERSECT",
                               dtype=None, description='',
                               mltype="classification", public=False,
                               partition=[100,0,0], sensors=[],
-                              url="{}/data".format(cfg.HOST), **kwargs):
+                              url="{}/data".format(cfg.host), **kwargs):
     """
         Loads a geojson file into the collection
 

--- a/pyveda/veda/loaders.py
+++ b/pyveda/veda/loaders.py
@@ -4,15 +4,13 @@ import mmap
 import numpy as np
 import requests
 from tempfile import NamedTemporaryFile
-from pyveda.auth import Auth
 from shapely.geometry import shape
 import warnings
+from pyveda.config import VedaConfig
 
-gbdx = Auth()
-HOST = os.environ.get('SANDMAN_API', "https://veda-api.geobigdata.io")
-conn = gbdx.gbdx_connection
+cfg = VedaConfig()
 
-def args_to_meta(name, description, dtype, imshape, 
+def args_to_meta(name, description, dtype, imshape,
                  mltype, partition, public, sensors):
     """
       Helper method for just building a dict of meta fields to pass to the API
@@ -27,22 +25,21 @@ def args_to_meta(name, description, dtype, imshape,
       'partition': partition,
       'sensors': sensors,
       'classes': [],
-      'bounds': None 
+      'bounds': None
     }
 
 
 def from_tarball(s3path, name=None, dtype='uint8',
                                     imshape=[3,256,256],
-                                    label_field=None, 
-                                    conn=conn,
+                                    label_field=None,
                                     default_label=None,
                                     mltype="classification",
                                     description="",
                                     public=False,
                                     sensors=[],
                                     partition=[100,0,0],
-                                    url="{}/data/bulk".format(HOST)):
-    dtype = np.dtype(dtype) 
+                                    url="{}/data/bulk".format(cfg.HOST)):
+    dtype = np.dtype(dtype)
     meta = args_to_meta(name, description, dtype, imshape, mltype, partition, public, sensors)
     options = {
         'default_label': default_label,
@@ -53,7 +50,7 @@ def from_tarball(s3path, name=None, dtype='uint8',
         'metadata': meta,
         'options': options
     }
-    doc = conn.post(url, json=body).json()
+    doc = cfg.conn.post(url, json=body).json()
     return doc
 
 
@@ -63,7 +60,7 @@ def from_geo(geojson, image, name=None, tilesize=[256,256], match="INTERSECT",
                               dtype=None, description='',
                               mltype="classification", public=False,
                               partition=[100,0,0], sensors=[],
-                              url="{}/data".format(HOST), conn=conn, **kwargs):
+                              url="{}/data".format(cfg.HOST), **kwargs):
     """
         Loads a geojson file into the collection
 
@@ -129,7 +126,7 @@ def from_geo(geojson, image, name=None, tilesize=[256,256], match="INTERSECT",
             'file': (os.path.basename(geojson), mfile, 'application/text'),
             'options': (None, json.dumps(options), 'application/json')
         }
-        r = conn.post(url, files=body)
+        r = cfg.conn.post(url, files=body)
         if r.status_code <= 201:
             return r.json()
         else:


### PR DESCRIPTION
This makes use of the `pyveda.config` module to provide access patterns to both the veda host url as well as easy access to a gbdx connection. Also includes some convenience functions in that module to set the veda destination, and provides `VedaConfig` as a class that can be either subclassed to provide `self.conn` and `self.host` on the class or can just be used by instantiating after import to get the same access.

convenience functions:
`pv.config.set_prod()`
`pv.config.set_dev()`
`pv.config.set_local()`
`pv.config.set_host(<host>)`

VedaConfig usage:
```
from pyveda.config import VedaConfig as vc
cfg = vc()
print("my host is {}".format(cfg.host)
print("i have a connection: {}".format(cfg.conn)
```
or 
```
from pyveda.config import VedaConfig
class MyNetworkClass(VedaConfig):
        print(self.host, self.conn)
```

Note that at any time, changing the HOST via the config host-setting convenience functions will change the host on all existing objects. This should make things convenient for development and usage.

By default, the global HOST var is set to veda production on initial import.