### PR TITLE
Mlt 207 add preview to labelizer

### DIFF
--- a/pyveda/veda/api.py
+++ b/pyveda/veda/api.py
@@ -483,3 +483,13 @@ class VedaCollectionProxy(_VedaCollectionProxy):
         classes = self.classes
         mltype = self.mltype
         Labelizer(self, mltype, count, classes).clean()
+
+    def preview(self, count=None):
+        """
+        Page through VedaCollection data and flag bad data.
+        Params:
+            count: the number of tiles to clean
+        """
+        classes = self.classes
+        mltype = self.mltype
+        Labelizer(self, mltype, count, classes).preview()

--- a/pyveda/vv/labelizer.py
+++ b/pyveda/vv/labelizer.py
@@ -98,7 +98,7 @@ class Labelizer():
 
     def _create_preview_buttons(self):
         buttons = []
-        actions = ['Show next tiles', 'Show previous tiles', 'Exit']
+        actions = ['Show next tile set', 'Exit']
         for b in actions:
             btn = Button(description=b)
             buttons.append(btn)
@@ -138,14 +138,7 @@ class Labelizer():
         self.clean()
 
     def _handle_preview_buttons(self, b):
-        if b.description == ('Show next tiles'):
-            self.preview()
-        elif b.description == ('Show previous tiles'):
-            #TODO: figure out why this doesn't work
-            self.index -= self.count
-            self.datapoint = self.vedaset[self.index]
-            self.image = self._create_images()
-            self.labels = self._create_labels()
+        if b.description == ('Show next tile set'):
             self.preview()
         elif b.description == 'Exit':
             clear_output()

--- a/pyveda/vv/labelizer.py
+++ b/pyveda/vv/labelizer.py
@@ -186,7 +186,6 @@ class Labelizer():
         """
         legend_elements = []
         ax = plt.subplot()
-        plt.title('Is this tile correct?', fontsize=14)
         for i, shp in enumerate(self.labels):
             if len(shp) is not 0:
                 edge_color = np.random.rand(3,)
@@ -208,14 +207,12 @@ class Labelizer():
         for i, binary_class in enumerate(self.labels):
             if binary_class != 0:
                 positive_classes.append(self.classes[i])
-        plt.title('Does this tile contain: %s?' % ', '.join(positive_classes), fontsize=14)
 
     def _display_segmentation(self):
         """
         Adds vedaset classification labels to the image plot.
         """
         ax = plt.subplot()
-        plt.title('Is this tile correct?', fontsize=14)
         if isinstance(self.vedaset, veda.api.VedaCollectionProxy):
             legend_elements = []
             for i, shp in enumerate(self.labels):
@@ -256,13 +253,15 @@ class Labelizer():
         for b in buttons:
             b.on_click(self._handle_flag_buttons)
         if self.datapoint is not None:
+            plt.title('Is this tile correct?', fontsize=14)
             self._display_image()
             if self.mltype == 'object_detection':
                 self._display_obj_detection()
             if self.mltype == 'classification':
+                ax.title('Does this tile contain: %s?' % ', '.join(positive_classes), fontsize=14)
                 self._display_classification()
             if self.mltype == 'segmentation':
-                self._display_segmentation()
+                ax._display_segmentation()
             print('Do you want to remove this tile?')
             display(HBox(buttons))
 

--- a/pyveda/vv/labelizer.py
+++ b/pyveda/vv/labelizer.py
@@ -1,6 +1,6 @@
 try:
     import ipywidgets as widgets
-    from ipywidgets import Button, HBox, VBox, RadioButtons
+    from ipywidgets import Button, HBox, VBox, RadioButtons, interact
     has_ipywidgets = True
 except:
     has_ipywidgets = False
@@ -281,11 +281,12 @@ class Labelizer():
                 print("All tiles have been cleaned.")
 
     def preview(self):
-        if self.image is not None and self.index != self.count:
-            self._display_image()
-            if self.mltype == 'object_detection':
-                self._display_obj_detection()
-            if self.mltype == 'classification':
-                self._display_classification()
-            if self.mltype == 'segmentation':
-                self._display_segmentation()
+        interact(self._display_image, idx=widgets.IntSlider(min=0, max=self.count, step=1, value=0))
+        # if self.image is not None and self.index != self.count:
+        #     self._display_image()
+        #     if self.mltype == 'object_detection':
+        #         self._display_obj_detection()
+        #     if self.mltype == 'classification':
+        #         self._display_classification()
+        #     if self.mltype == 'segmentation':
+        #         self._display_segmentation()

--- a/pyveda/vv/labelizer.py
+++ b/pyveda/vv/labelizer.py
@@ -209,6 +209,8 @@ class Labelizer():
                 positive_classes.append(self.classes[i])
         if title==True:
             plt.title('Does this tile contain: %s?' % ', '.join(positive_classes), fontsize=14)
+        else:
+            plt.title('Tile contains: %s' % ', '.join(positive_classes), fontsize=14)
 
     def _display_segmentation(self, title=True):
         """

--- a/pyveda/vv/labelizer.py
+++ b/pyveda/vv/labelizer.py
@@ -145,6 +145,10 @@ class Labelizer():
         except StopIteration:
             print("All flagged tiles have been cleaned.")
 
+    def _recolor_images(self):
+        img = self.image
+
+
     def _display_image(self):
         """
         Displays image tile for a given vedaset object.
@@ -212,8 +216,14 @@ class Labelizer():
                         ax.fill(x,y, color=face_color, alpha=0.4)
                         ax.plot(x,y, lw=3, color=face_color)
         else:
-            ax.imshow(self.labels, alpha=0.5)
-            #TODO: add legend for this type of label
+            im = ax.imshow(self.labels, alpha=0.5)
+            values = np.unique(self.labels.ravel())
+            colors = [im.cmap(im.norm(value)) for value in values]
+            try:
+                lpatches = [patches.Patch(color=colors[i+1], label=a) for i,a in enumerate(self.classes)]
+                ax.legend(handles=lpatches, bbox_to_anchor=(0.5,-0.1))
+            except:
+                pass
 
 
     def clean_flags(self):

--- a/pyveda/vv/labelizer.py
+++ b/pyveda/vv/labelizer.py
@@ -139,12 +139,13 @@ class Labelizer():
 
     def _handle_preview_buttons(self, b):
         if b.description == ('Show next tiles'):
-            ##add functionality
-            print('show more tiles')
+            self.preview()
         elif b.description == ('Show previous tiles'):
             ##add functionality
             print('show less tiles')
-        self.preview()
+        elif b.description == 'Exit':
+            clear_output()
+            return
 
 
     def _handle_flag_buttons(self, b):
@@ -308,6 +309,7 @@ class Labelizer():
         buttons = self._create_preview_buttons()
         for b in buttons:
             b.on_click(self._handle_preview_buttons)
+        display(HBox(buttons))
         for c in range(self.count):
             self._display_image()
             if self.mltype == 'object_detection':

--- a/pyveda/vv/labelizer.py
+++ b/pyveda/vv/labelizer.py
@@ -180,10 +180,12 @@ class Labelizer():
         ax.imshow(img)
         # return(img)
 
-    def _display_obj_detection(self):
+    def _display_obj_detection(self, title=True):
         """
         Adds vedaset object detection label geometries to the image tile plot.
         """
+        if title==True:
+            plt.title('Is this tile correct?', fontsize=14)
         legend_elements = []
         ax = plt.subplot()
         for i, shp in enumerate(self.labels):
@@ -199,7 +201,7 @@ class Labelizer():
                             fill=False, lw=2))
 
 
-    def _display_classification(self):
+    def _display_classification(self, title=True):
         """
         Adds vedaset classification labels to the image plot.
         """
@@ -207,11 +209,15 @@ class Labelizer():
         for i, binary_class in enumerate(self.labels):
             if binary_class != 0:
                 positive_classes.append(self.classes[i])
+        if title==True:
+            plt.title('Does this tile contain: %s?' % ', '.join(positive_classes), fontsize=14)
 
-    def _display_segmentation(self):
+    def _display_segmentation(self, title=True):
         """
         Adds vedaset classification labels to the image plot.
         """
+        if title==True:
+            plt.title('Is this tile correct?', fontsize=14)
         ax = plt.subplot()
         if isinstance(self.vedaset, veda.api.VedaCollectionProxy):
             legend_elements = []
@@ -258,7 +264,6 @@ class Labelizer():
             if self.mltype == 'object_detection':
                 self._display_obj_detection()
             if self.mltype == 'classification':
-                ax.title('Does this tile contain: %s?' % ', '.join(positive_classes), fontsize=14)
                 self._display_classification()
             if self.mltype == 'segmentation':
                 ax._display_segmentation()
@@ -306,11 +311,11 @@ class Labelizer():
         for c in range(self.count):
             self._display_image()
             if self.mltype == 'object_detection':
-                self._display_obj_detection()
+                self._display_obj_detection(title=False)
             if self.mltype == 'classification':
-                self._display_classification()
+                self._display_classification(title=False)
             if self.mltype == 'segmentation':
-                self._display_segmentation()
+                self._display_segmentation(title=False)
             plt.show()
             self.index += 1
             self.datapoint = self.vedaset[self.index]

--- a/pyveda/vv/labelizer.py
+++ b/pyveda/vv/labelizer.py
@@ -1,6 +1,6 @@
 try:
     import ipywidgets as widgets
-    from ipywidgets import Button, HBox, VBox, RadioButtons, interact
+    from ipywidgets import Button, HBox, VBox, interact, IntSlider
     has_ipywidgets = True
 except:
     has_ipywidgets = False
@@ -159,7 +159,7 @@ class Labelizer():
         ax = plt.subplot()
         ax.axis("off")
         ax.imshow(img)
-        return(img)
+        # return(img)
 
     def _display_obj_detection(self):
         """
@@ -279,9 +279,21 @@ class Labelizer():
                 self.clean_flags()
             except StopIteration:
                 print("All tiles have been cleaned.")
+    # def _create_slider(self):
+    #     """
+    #     Creates ipywidget widget sliders
+    #     Returns:
+    #         buttons: A list of ipywidget Button() objects
+    #     """
+    #     w = widgets.IntSlider()
+    #     w.value = self.count
+    #     return(w)
+    #
+    #     return buttons
 
     def preview(self):
-        interact(self._display_image, idx=widgets.IntSlider(min=0, max=self.count, step=1, value=0))
+        # display()
+        interact(self._display_image, idx=IntSlider(min=0, max=self.count, step=1, value=0))
         # if self.image is not None and self.index != self.count:
         #     self._display_image()
         #     if self.mltype == 'object_detection':

--- a/pyveda/vv/labelizer.py
+++ b/pyveda/vv/labelizer.py
@@ -146,7 +146,7 @@ class Labelizer():
             self.datapoint = self.vedaset[self.index]
             self.image = self._create_images()
             self.labels = self._create_labels()
-            # self.preview()
+            self.preview()
             print(self.index)
         elif b.description == 'Exit':
             clear_output()
@@ -315,7 +315,7 @@ class Labelizer():
         for b in buttons:
             b.on_click(self._handle_preview_buttons)
         display(HBox(buttons))
-        for c in range(self.count):
+        while self.index < self.count:
             self._display_image()
             if self.mltype == 'object_detection':
                 self._display_obj_detection(title=False)

--- a/pyveda/vv/labelizer.py
+++ b/pyveda/vv/labelizer.py
@@ -279,26 +279,19 @@ class Labelizer():
                 self.clean_flags()
             except StopIteration:
                 print("All tiles have been cleaned.")
-    # def _create_slider(self):
-    #     """
-    #     Creates ipywidget widget sliders
-    #     Returns:
-    #         buttons: A list of ipywidget Button() objects
-    #     """
-    #     w = widgets.IntSlider()
-    #     w.value = self.count
-    #     return(w)
-    #
-    #     return buttons
+
 
     def preview(self):
-        # display()
-        interact(self._display_image, idx=IntSlider(min=0, max=self.count, step=1, value=0))
-        # if self.image is not None and self.index != self.count:
-        #     self._display_image()
-        #     if self.mltype == 'object_detection':
-        #         self._display_obj_detection()
-        #     if self.mltype == 'classification':
-        #         self._display_classification()
-        #     if self.mltype == 'segmentation':
-        #         self._display_segmentation()
+        for c in range(self.count):
+            self._display_image()
+            if self.mltype == 'object_detection':
+                self._display_obj_detection()
+            if self.mltype == 'classification':
+                self._display_classification()
+            if self.mltype == 'segmentation':
+                self._display_segmentation()
+            plt.show()
+            self.index += 1
+            self.datapoint = self.vedaset[self.index]
+            self.image = self._create_images()
+            self.labels = self._create_labels()

--- a/pyveda/vv/labelizer.py
+++ b/pyveda/vv/labelizer.py
@@ -140,7 +140,6 @@ class Labelizer():
     def _handle_preview_buttons(self, b):
         if b.description == ('Show next tiles'):
             self.preview()
-            print(self.index)
         elif b.description == ('Show previous tiles'):
             #TODO: figure out why this doesn't work
             self.index -= self.count
@@ -148,7 +147,6 @@ class Labelizer():
             self.image = self._create_images()
             self.labels = self._create_labels()
             self.preview()
-            print(self.index)
         elif b.description == 'Exit':
             clear_output()
             return
@@ -325,9 +323,7 @@ class Labelizer():
             if self.mltype == 'segmentation':
                 self._display_segmentation(title=False)
             plt.show()
-            print(self.index)
             self.index += 1
             self.datapoint = self.vedaset[self.index]
             self.image = self._create_images()
             self.labels = self._create_labels()
-            print(self.index)

--- a/pyveda/vv/labelizer.py
+++ b/pyveda/vv/labelizer.py
@@ -14,6 +14,7 @@ except:
 try:
     import matplotlib.pyplot as plt
     import matplotlib.patches as patches
+    from matplotlib.colors import LinearSegmentedColormap
     has_plt = True
 except:
     has_plt = False
@@ -216,7 +217,13 @@ class Labelizer():
                         ax.fill(x,y, color=face_color, alpha=0.4)
                         ax.plot(x,y, lw=3, color=face_color)
         else:
-            im = ax.imshow(self.labels, alpha=0.5)
+            legend_colors = [(0.5,0.5,0.5)]
+            cmap_name = 'segmentation_labels'
+            for i, shp in enumerate(self.classes):
+                color = np.random.rand(3,)
+                legend_colors.append(color)
+            cm = LinearSegmentedColormap.from_list(cmap_name, legend_colors, N=100)
+            im = ax.imshow(self.labels, alpha=0.5, cmap=cm)
             values = np.unique(self.labels.ravel())
             colors = [im.cmap(im.norm(value)) for value in values]
             try:
@@ -224,6 +231,9 @@ class Labelizer():
                 ax.legend(handles=lpatches, bbox_to_anchor=(0.5,-0.1))
             except:
                 pass
+
+
+
 
 
     def clean_flags(self):

--- a/pyveda/vv/labelizer.py
+++ b/pyveda/vv/labelizer.py
@@ -96,6 +96,15 @@ class Labelizer():
             buttons.append(btn)
         return buttons
 
+    def _create_preview_buttons(self):
+        buttons = []
+        actions = ['Show next tiles', 'Show previous tiles', 'Exit']
+        for b in actions:
+            btn = Button(description=b)
+            buttons.append(btn)
+        return buttons
+
+
     def _create_flag_buttons(self):
         """
         Creates ipywidget widget buttons for tiles that have been flagged for review.
@@ -127,6 +136,16 @@ class Labelizer():
         elif b.description == 'Exit':
             self.index = self.count
         self.clean()
+
+    def _handle_preview_buttons(self, b):
+        if b.description == ('Show next tiles'):
+            ##add functionality
+            print('show more tiles')
+        elif b.description == ('Show previous tiles'):
+            ##add functionality
+            print('show less tiles')
+        self.preview()
+
 
     def _handle_flag_buttons(self, b):
         """
@@ -280,8 +299,11 @@ class Labelizer():
             except StopIteration:
                 print("All tiles have been cleaned.")
 
-
     def preview(self):
+        clear_output()
+        buttons = self._create_preview_buttons()
+        for b in buttons:
+            b.on_click(self._handle_preview_buttons)
         for c in range(self.count):
             self._display_image()
             if self.mltype == 'object_detection':

--- a/pyveda/vv/labelizer.py
+++ b/pyveda/vv/labelizer.py
@@ -142,6 +142,7 @@ class Labelizer():
             self.preview()
             print(self.index)
         elif b.description == ('Show previous tiles'):
+            #TODO: figure out why this doesn't work
             self.index -= self.count
             self.datapoint = self.vedaset[self.index]
             self.image = self._create_images()
@@ -315,7 +316,7 @@ class Labelizer():
         for b in buttons:
             b.on_click(self._handle_preview_buttons)
         display(HBox(buttons))
-        while self.index < self.count:
+        for c in range(0, self.count):
             self._display_image()
             if self.mltype == 'object_detection':
                 self._display_obj_detection(title=False)
@@ -324,7 +325,9 @@ class Labelizer():
             if self.mltype == 'segmentation':
                 self._display_segmentation(title=False)
             plt.show()
+            print(self.index)
             self.index += 1
             self.datapoint = self.vedaset[self.index]
             self.image = self._create_images()
             self.labels = self._create_labels()
+            print(self.index)

--- a/pyveda/vv/labelizer.py
+++ b/pyveda/vv/labelizer.py
@@ -146,10 +146,6 @@ class Labelizer():
         except StopIteration:
             print("All flagged tiles have been cleaned.")
 
-    def _recolor_images(self):
-        img = self.image
-
-
     def _display_image(self):
         """
         Displays image tile for a given vedaset object.
@@ -232,10 +228,6 @@ class Labelizer():
             except:
                 pass
 
-
-
-
-
     def clean_flags(self):
         """
         Method for verifying DataPoints that were flagged with clean()
@@ -287,3 +279,13 @@ class Labelizer():
                 self.clean_flags()
             except StopIteration:
                 print("All tiles have been cleaned.")
+
+    def preview(self):
+        if self.image is not None and self.index != self.count:
+            self._display_image()
+            if self.mltype == 'object_detection':
+                self._display_obj_detection()
+            if self.mltype == 'classification':
+                self._display_classification()
+            if self.mltype == 'segmentation':
+                self._display_segmentation()

--- a/pyveda/vv/labelizer.py
+++ b/pyveda/vv/labelizer.py
@@ -140,9 +140,14 @@ class Labelizer():
     def _handle_preview_buttons(self, b):
         if b.description == ('Show next tiles'):
             self.preview()
+            print(self.index)
         elif b.description == ('Show previous tiles'):
-            ##add functionality
-            print('show less tiles')
+            self.index -= self.count
+            self.datapoint = self.vedaset[self.index]
+            self.image = self._create_images()
+            self.labels = self._create_labels()
+            # self.preview()
+            print(self.index)
         elif b.description == 'Exit':
             clear_output()
             return


### PR DESCRIPTION
This branch allows the user to page through a vcp and preview sets of tiles. For instance:

```
dataset = pv.from_id('c3fcef8b-086d-4aa2-9862-522078870a6c')
dataset.preview(count=5)
```
will allow the user to look at the dataset in batches of five. There are ipywidget buttons for the user to click through the batches with.