### PR TITLE
MLT 219

### DIFF
--- a/pyveda/frameworks/batch_generator.py
+++ b/pyveda/frameworks/batch_generator.py
@@ -17,13 +17,14 @@ class BaseGenerator():
     flip_vertical: boolean. Vertically flip image and lables
     '''
 
-    def __init__(self, cache, batch_size=32, shuffle=True, channels_last=False, rescale=False,
+    def __init__(self, cache, batch_size=32, shuffle=True, channels_last=False, expand_dims=False rescale=False,
                     flip_horizontal=False, flip_vertical=False):
         self.cache = cache
         self.batch_size = batch_size
         self.index = 0
         self.shuffle = shuffle
         self.channels_last = channels_last
+        self.expand_dims = expand_dims
         self.rescale = rescale
         self.on_epoch_end()
         self.flip_h = flip_horizontal
@@ -156,6 +157,9 @@ class VedaStoreGenerator(BaseGenerator):
             if self.channels_last:
                 x_img = x_img.T
             x[i, ] = x_img
+
+            if self.expand_dims:
+                y_img = np.expand_dims(y_img, 2)
             y.append(y_img)
 
         #rescale after entire bactch is collected
@@ -194,6 +198,9 @@ class VedaStreamGenerator(BaseGenerator):
             if self.channels_last:
                 x_img = x_img.T
             x[len(y), ] = x_img
+
+            if self.expand_dims:
+                y_img = np.expand_dims(y_img, 2)
             y.append(y_img)
 
         if self.rescale:

--- a/pyveda/frameworks/batch_generator.py
+++ b/pyveda/frameworks/batch_generator.py
@@ -17,7 +17,7 @@ class BaseGenerator():
     flip_vertical: boolean. Vertically flip image and lables
     '''
 
-    def __init__(self, cache, batch_size=32, shuffle=True, channels_last=False, expand_dims=False rescale=False,
+    def __init__(self, cache, batch_size=32, shuffle=True, channels_last=False, expand_dims=False, rescale=False,
                     flip_horizontal=False, flip_vertical=False):
         self.cache = cache
         self.batch_size = batch_size

--- a/pyveda/vedaset/store/vedabase.py
+++ b/pyveda/vedaset/store/vedabase.py
@@ -36,7 +36,7 @@ class WrappedDataNode(object):
     def labels(self):
         return self._vset._label_array_factory(self._node.hit_table, self._node.labels,  self._vset)
 
-    def batch_generator(self, batch_size, shuffle=True, channels_last=False, rescale=False, flip_horizontal=False, flip_vertical=False, **kwargs):
+    def batch_generator(self, batch_size, shuffle=True, channels_last=False, expand_dims=False, rescale=False, flip_horizontal=False, flip_vertical=False, **kwargs):
         """
         Generatates Batch of Images/Lables on a VedaBase partition.
         #Arguments
@@ -48,7 +48,7 @@ class WrappedDataNode(object):
             flip_vertical: Boolean. Vertically flip image and lables
         """
         return VedaStoreGenerator(self, batch_size=batch_size, shuffle=shuffle,
-                                channels_last=channels_last, rescale=rescale,
+                                channels_last=channels_last, expand_dims = expand_dims, rescale=rescale,
                                 flip_horizontal=flip_horizontal, flip_vertical=flip_vertical, **kwargs)
 
     def __getitem__(self, spec):

--- a/pyveda/vedaset/stream/vedastream.py
+++ b/pyveda/vedaset/stream/vedastream.py
@@ -104,7 +104,7 @@ class BufferedSampleArray(BaseSampleArray):
                 batch.append(self.__next__())
             yield batch
 
-    def batch_generator(self, batch_size, shuffle=True, channels_last=False, rescale=False, flip_horizontal=False, flip_vertical=False, **kwargs):
+    def batch_generator(self, batch_size, shuffle=True, channels_last=False, expand_dims=False, rescale=False, flip_horizontal=False, flip_vertical=False, **kwargs):
         """
         Generatates Batch of Images/Lables on a VedaStream partition.
         #Arguments
@@ -116,7 +116,7 @@ class BufferedSampleArray(BaseSampleArray):
             flip_vertical: Boolean. Vertically flip image and lables
         """
         return VedaStreamGenerator(self, batch_size=batch_size, shuffle=shuffle,
-                                channels_last=channels_last, rescale=rescale,
+                                channels_last=channels_last, expand_dims = expand_dims,rescale=rescale,
                                 flip_horizontal=flip_horizontal, flip_vertical=flip_vertical, **kwargs)
 
     @property


### PR DESCRIPTION
Add expand dimensions as a boolean option for `augmentation_generator` base class. 

Pixel decoder's implementation of a unet, with the conv2d layers, needs a dimension of 1 added to the label array, and other model implementations could also need this. 
This allows for:
`(batch_size, width, height)` to become `(batch_size, width, height, 1)`  