### PR TITLE
Mlt 228 prediction results

### DIFF
--- a/pyveda/main.py
+++ b/pyveda/main.py
@@ -7,6 +7,7 @@ from pyveda.vedaset import VedaBase, VedaStream
 from pyveda.veda.loaders import from_geo, from_tarball
 from pyveda.fetch.compat import build_vedabase
 from pyveda.veda.api import _bec, VedaCollectionProxy
+from pyveda.models import Model 
 
 cfg = VedaConfig()
 
@@ -16,7 +17,8 @@ __all__ = ["search",
            "from_id",
            "from_name",
            "create_from_geojson",
-           "create_from_tarball"]
+           "create_from_tarball",
+           "model_from_id"]
 
 def _map_contains_submap(mmap, submap, hard_match=True):
     """ Checks if a submap is contained in a master map.
@@ -54,6 +56,18 @@ def search(params={}, filters={}, **kwargs):
     results = r.json()
     return [VedaCollectionProxy.from_doc(s) for s in results
             if _map_contains_submap(s["properties"], filters, **kwargs)]
+
+def model_from_id(model_id):
+    """ 
+      Initialize a Model class from an id
+
+      Args:
+          model_id (str): the id of the model
+
+      Returns:
+          model (Model): the pyveda model class for the tis
+    """
+    return Model.from_id(model_id)
 
 def from_id(dataset_id):
     ''' Returns the dataset as a VedaCollectionProxy from an ID if it exists.

--- a/pyveda/models/__init__.py
+++ b/pyveda/models/__init__.py
@@ -1,1 +1,1 @@
-from pyveda.models.main import search, Model
+from pyveda.models.main import Model, PredictionSet

--- a/pyveda/models/main.py
+++ b/pyveda/models/main.py
@@ -10,14 +10,10 @@ from pyveda.config import VedaConfig
 
 cfg = VedaConfig()
 
-def search(params={}):
-    r = cfg.conn.post('{}/models/search'.format(cfg.host), json=params)
-    try:
-        results = r.json()
-        return [Model.from_doc(s) for s in results]
-    except Exception as err:
-        print(err)
-        return []
+def search(url, params={}):
+    r = cfg.conn.post(url, json=params)
+    r.raise_for_status()
+    return r.json()
 
 def create_archive(model, weights): 
     """ Creates a tar from a model """
@@ -79,6 +75,11 @@ class Model(object):
         r = cfg.conn.get(url)
         r.raise_for_status()
         return cls.from_doc(r.json())
+
+    @classmethod
+    def search(cls, **kwargs):
+        results = search('{}/models/search'.format(cfg.host), **kwargs)
+        return [Model.from_doc(s) for s in results]
 
     def save(self):
         payload = MultipartEncoder(
@@ -269,4 +270,10 @@ class PredictionSet(VedaCollectionProxy):
             return [cls.from_doc(s) for s in results]
         except Exception as err:
             return []
+    
+    @classmethod
+    def search(cls, **kwargs):
+        results = search('{}/predictions/search'.format(cfg.host), **kwargs)
+        return [cls.from_doc(s) for s in results]
+
 

--- a/pyveda/models/main.py
+++ b/pyveda/models/main.py
@@ -263,15 +263,6 @@ class PredictionSet(VedaCollectionProxy):
         return cls.from_doc(r.json())
 
     @classmethod
-    def search(cls, params={}):
-        r = cfg.conn.post('{}/predictions/search'.format(cfg.host), json=params)
-        try:
-            results = r.json()
-            return [cls.from_doc(s) for s in results]
-        except Exception as err:
-            return []
-    
-    @classmethod
     def search(cls, **kwargs):
         results = search('{}/predictions/search'.format(cfg.host), **kwargs)
         return [cls.from_doc(s) for s in results]

--- a/pyveda/models/main.py
+++ b/pyveda/models/main.py
@@ -3,6 +3,7 @@ import tarfile
 import tempfile
 import mmap
 import json
+from pyveda.utils import url_to_numpy
 from requests_toolbelt.multipart.encoder import MultipartEncoder
 from pyveda.veda.api import DataSampleClient, VedaCollectionProxy
 from pyveda.config import VedaConfig
@@ -232,8 +233,10 @@ class Model(object):
 
 
 class PredictionSampleClient(DataSampleClient):
-  def raw(self):
-      print('get raw data')
+  @property
+  def prediction(self):
+      url = "{}/predictions/result/{}".format(cfg.host, self.id)
+      return url_to_numpy(url, cfg.conn.access_token)
 
 class PredictionSet(VedaCollectionProxy):
     """ Methods for accessing training data pairs """
@@ -241,7 +244,6 @@ class PredictionSet(VedaCollectionProxy):
 
     def __init__(self, **kwargs):
         self._meta = {k: v for k, v in kwargs.items() if k in self._metaprops}
-        #self.links = kwargs.get('links')
         self._dataset_base_furl = "{host_url}/predictions/{dataset_id}"
         self.id = kwargs.get('id')
         self._dataset_id = self.id

--- a/pyveda/utils.py
+++ b/pyveda/utils.py
@@ -38,6 +38,25 @@ def url_to_array(url, token):
       except Exception as err:
           print('Error fetching image...', err)
 
+def url_to_numpy(url, token):
+    _curl = pycurl.Curl()
+    _curl.setopt(_curl.URL, url)
+    _curl.setopt(pycurl.NOSIGNAL, 1)
+    _curl.setopt(pycurl.HTTPHEADER, ['Authorization: Bearer {}'.format(token)])
+    with NamedTemporaryFile(prefix="veda", suffix=".npy", delete=False) as temp:
+      try:
+          _curl.setopt(_curl.WRITEDATA, temp.file)
+          _curl.perform()
+          code = _curl.getinfo(pycurl.HTTP_CODE)
+          if code != 200:
+             raise TypeError("Request for {} returned unexpected error code: {}".format(url, code))
+          temp.file.flush()
+          temp.close()
+          _curl.close()
+          return np.load(temp.name)
+      except Exception as err:
+          print('Error fetching image...', err)
+
 
 def check_unexpected_kwargs(kwargs, **unexpected):
     for key, message in unexpected.items():

--- a/pyveda/veda/loaders.py
+++ b/pyveda/veda/loaders.py
@@ -94,6 +94,8 @@ def from_geo(geojson, image, name=None, tilesize=[256,256], match="INTERSECT",
             temp.file.write(json.dumps(geojson))
         geojson = temp.name
 
+    assert len(geojson['features']), "No features found in geojson. At least one feature is needed for creating data." 
+
     if dtype is None:
        dtype = image.dtype
     else:

--- a/tests/unit/cassettes/test_main_model_from_id.yaml
+++ b/tests/unit/cassettes/test_main_model_from_id.yaml
@@ -1,0 +1,35 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://veda-api-development.geobigdata.io/models/eb1e1e0b-c48e-494f-b56a-4bb0734c98fc
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA71SW0/bMBT+K8jPuTVxmqavkLFKMKq1PCGEHPs0sXDsyHGYOsZ/33Haamhi0/YA
+        lhxLX47Pdzl+Jm7fA1mST8DcaIEEpAHTgbN7snw+/bwelZNro/aN0VjBjbFCauZgIMs7XGFZRMW8
+        KDMaZEmUzvMiye6D3+FiluX0BGdZSud/g//Q5ADjeglIb00P1kkvA7VaJrXUzcMADjXPUponRbYL
+        BYMypAnjIeM5D/OUs4yWDBZCeC+KDcPkg9SjVGirIfcBEdArswfhG0v86lGpFw8P3MreScxhwhA6
+        ZjRK7RbYcBzArvAGYaNrkx85kqY8nycJzfKCUpos8myXplgpu6Fl/u5dms8Dv0nmuTt1bDlA04F2
+        bKJDqS3TGtTwgJK9Q2dHPy8la8v8uMgjWDYg0o+1kvxXRW1GLbzFt7IM3h4H0azzGs4/V1fXZ5vq
+        8mz9tbpYnW9XN182ntXwg64l6YxAVTHUM5hBUoecLiCkJd2FdT5nIa1rnAPl5WLH46k2csxGzXcf
+        gQ/qXy5OPvXjNOgB1M6frQU8SetcPyzj+AkEC1kvQwFPoEzvo4vwMdeyEcyxSJr4P5SSadoKHLw/
+        FY4cXGt8FhfVVbWtPPnYY6uPJV/fbg+2/dt/d+b4yPNawM3moMB808ow8QEaTkyvVFxWKALXT6Me
+        p60cBQAA
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Connection: [keep-alive]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 04 Mar 2019 13:53:22 GMT']
+      ETag: [W/"51c-FJIHz4RUtyvHvbXT1MJYCeS/W3g"]
+      Vary: [Accept-Encoding]
+      X-Powered-By: [Express]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/unit/cassettes/test_model_create.yaml
+++ b/tests/unit/cassettes/test_model_create.yaml
@@ -1,0 +1,38 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python-requests/2.18.4]
+    method: GET
+    uri: https://veda-api-development.geobigdata.io/data/1245073f-dae9-40ac-ac5c-52ca349ae8dd
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA71U24rUQBD9Fclzpqfvl3kTXEFQXFCflmXpdGpmGjNJTDoL6+i/W51MHtZVEWTt
+        EEJ1ddc5py45F+mhh2JXvAafpgGKsjhAd4I0PBS78+p8NzUpXnfNw6Fr8UTouqGOrU8wFrsbXBtn
+        iNHGCVkKSrhWhorb8udtw4SS67YQXOo/bf8myLKN63tZ9EPXw5BipnEu4skf4G6AfSaF1OHUN0gR
+        6Vtjla6Cswq0syChUjUNxlhpDAt2XynGjK8ts0GGPQgFCqy3FAzXDiqOktuuzpFSbOBujF9znrr9
+        foSUwQrGOBFUamsUOh5bnDmCcZTmiyWJlWI5ZynRWtLFo60gyi0e6yy5HHJMEGoXx21ZjME3sGBq
+        RYlwl9vMOkckW4NxZjixiq2oijvC3crIaEG0YauFPun4xRRSccLkyhFL44i9iLn9jgxC48dxoVBN
+        scE+OGRiNYxhiH2K2CG7Am/Wl96ZYpss2tMIw5saN/yUjvSb8kHxoDSlUigjpUSRYs9zruNpPPp8
+        90aUXOn8IsAADfgZ+IylPzWX8CMcTtAmPwNjS3jsh4XEDaO0xCdnDdqxG2bO796+yX2SKfdT1cSQ
+        qzpMuaBfJpgWYfdQ+w3jUlEj9pvag9tI6sMGOYcN0vZCOg+2rjeVs9F+VsHbk84xq25q6xzjV21b
+        /rrzi9afspSX05hi++LDY0Ux5+xvuMyDObWp2HFFUR0MAcPcBR+OgDFyNoomtp/nYRmh2efvEecF
+        4x9T6sfddjsL933c1HAPTddnIgR/CFU81D55Ertt/m7/ig+WaerreQSfFwjbAdKxy4m6/vQx486l
+        HY/PDLxdYZ4SqLFb/6vwV1dvrz5eZegwwD/lvO9wYsdHmt5/mEVdRvC5s7rCPGGA6wcjEQpmsAYA
+        AA==
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Connection: [keep-alive]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Mon, 04 Mar 2019 22:13:47 GMT']
+      ETag: [W/"6b0-dde+2Aewr94WwnKDw3MeAVuccWg"]
+      Vary: [Accept-Encoding]
+      X-Powered-By: [Express]
+      transfer-encoding: [chunked]
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -7,6 +7,7 @@ from auth_mock import conn, my_vcr
 from pyveda.veda.api import VedaCollectionProxy
 from pyveda.vedaset import VedaStream
 from pyveda.vedaset import VedaBase
+from pyveda.models import Model
 
 import pyveda as pv
 pv.config.set_dev()
@@ -20,7 +21,6 @@ class MainFunctionsTest(unittest.TestCase):
     @classmethod
     def setUpClass(self):
         self.id = '1245073f-dae9-40ac-ac5c-52ca349ae8dd'
-        #self.vcp = VedaCollectionProxy.from_id(id)
         self.h5 = './test.h5'
 
     @classmethod
@@ -72,3 +72,8 @@ class MainFunctionsTest(unittest.TestCase):
 
     def test_createfromgeojson(self):
         pass
+
+    @my_vcr.use_cassette('tests/unit/cassettes/test_main_model_from_id.yaml', filter_headers=['authorization'])
+    def test_model_from_id(self):
+        model = pv.model_from_id('eb1e1e0b-c48e-494f-b56a-4bb0734c98fc')
+        self.assertIsInstance(model, Model)

--- a/tests/unit/test_model.py
+++ b/tests/unit/test_model.py
@@ -1,0 +1,42 @@
+'''
+Tests for DataPoint that don't rely on the server
+'''
+import os, sys
+from auth_mock import conn, my_vcr
+import pyveda as pv
+pv.config.set_dev()
+pv.config.set_conn(conn)
+
+from pyveda.models import Model
+import json
+import unittest
+
+class ModelTest(unittest.TestCase):
+    @classmethod 
+    def setUpClass(self):
+        self.vc_id = '1245073f-dae9-40ac-ac5c-52ca349ae8dd'
+        self.model_id = 'eb1e1e0b-c48e-494f-b56a-4bb0734c98fc'
+
+    @my_vcr.use_cassette('tests/unit/cassettes/test_model_create.yaml', filter_headers=['authorization'])
+    def test_model_create(self):
+        vc = pv.from_id(self.vc_id)
+        archive = 'dummy.tar.gz'
+        model = Model('CHELM SEG PREDICTIONS', 
+            archive=archive,
+            library="keras",               
+            training_set=vc,
+            imshape=(256,256,3),
+            mltype='segmentation',
+            channels_last=True
+        )  
+        self.assertIsInstance(model, Model)
+        # public properties
+        self.assertTrue(model.channels_last)
+        self.assertEqual(model.library, "keras")
+        self.assertEqual(vc.bounds, model.bounds)
+        self.assertEqual(model.imshape, (256,256,3))
+        self.assertEqual(vc.mltype, model.mltype)
+
+    
+
+    

--- a/tests/unit/test_prediction_sets.py
+++ b/tests/unit/test_prediction_sets.py
@@ -1,0 +1,32 @@
+'''
+Tests for DataPoint that don't rely on the server
+'''
+import os, sys
+from auth_mock import conn, my_vcr
+import pyveda as pv
+pv.config.set_dev()
+pv.config.set_conn(conn)
+
+from pyveda.models.main import PredictionSet, PredictionSampleClient
+import json
+import unittest
+
+class PredictionTest(unittest.TestCase):
+    @classmethod 
+    def setUpClass(self):
+        self._id = '09a64c45-b6d3-4620-ad65-0512eae9f261'
+
+    @my_vcr.use_cassette('tests/unit/cassettes/test_prediction_set.yaml', filter_headers=['authorization'])
+    def test_prediction_set(self):
+        pass
+        # TODO cant pass until deployed to dev
+        #pset = PredictionSet.from_id(self._id)
+        #self.assertIsInstance(pset, PredictionSet)
+        ## public properties
+        #self.assertEqual(pset.bounds, [-97.7651149214, 30.2704546428, -97.7620965959, 30.2734729683])
+        #self.assertEqual(pset.classes, ['building'])
+        #self.assertEqual(pset.mltype, 'segmentation')
+
+    
+
+    


### PR DESCRIPTION
What does this PR do?
---------------------

- Adds support for predicting on models, which uses the qworker in a prediction mode to drive imagery through a given model.  


What steps, if any, do reviewers need to take to set up their environments to test this properly?
---------------------

- Its important that the qworker work as before, caching data to 100%. To reproduce the work in this PR you can init a model and call `model.predict(bounds, image)` and it will generate a prediction result set. Those result sets are capable of being searched for and used in a similar way to training data

Acceptance criteria
---------------------

- Caching works as it did before. 

Known issues
---------------------

-

:white_check_mark: Checklist
---------------------

- [x ] No additional work is in process. This PR should be ready for merge right now.
- [x] Tests are included
- [x] There is at least one assignee

Attn @msmith303
