### PR TITLE
Mlt 238 labelizer background tile filter

### DIFF
--- a/pyveda/veda/api.py
+++ b/pyveda/veda/api.py
@@ -465,7 +465,7 @@ class VedaCollectionProxy(_VedaCollectionProxy):
     def __geo_interface__(self):
         return box(*self.bounds).__geo_interface__
 
-    def clean(self, count=None, include_background_tiles=True):
+    def clean(self, count=None, include_background_tiles=True, return_flagged_tiles=False):
         """
         Page through VedaCollection data and flag bad data.
         Params:
@@ -473,9 +473,15 @@ class VedaCollectionProxy(_VedaCollectionProxy):
         """
         classes = self.classes
         mltype = self.mltype
-        Labelizer(self, mltype, count, classes, include_background_tiles).clean()
+        if return_flagged_tiles:
+            flagged_tiles = Labelizer(self, mltype, count, classes, include_background_tiles, return_flagged_tiles).clean()
+            return flagged_tiles
+        else:
+            Labelizer(self, mltype, count, classes, include_background_tiles, return_flagged_tiles).clean()
 
-    def preview(self, count=10, include_background_tiles=True):
+
+
+    def preview(self, count=10, include_background_tiles=True, return_flagged_tiles=False):
         """
         Page through VedaCollection data and flag bad data.
         Params:
@@ -483,4 +489,4 @@ class VedaCollectionProxy(_VedaCollectionProxy):
         """
         classes = self.classes
         mltype = self.mltype
-        Labelizer(self, mltype, count, classes, include_background_tiles).preview()
+        Labelizer(self, mltype, count, classes, include_background_tiles, return_flagged_tiles).preview()

--- a/pyveda/veda/api.py
+++ b/pyveda/veda/api.py
@@ -475,7 +475,7 @@ class VedaCollectionProxy(_VedaCollectionProxy):
         mltype = self.mltype
         Labelizer(self, mltype, count, classes, include_background_tiles).clean()
 
-    def preview(self, count=10):
+    def preview(self, count=10, include_background_tiles=True):
         """
         Page through VedaCollection data and flag bad data.
         Params:
@@ -483,4 +483,4 @@ class VedaCollectionProxy(_VedaCollectionProxy):
         """
         classes = self.classes
         mltype = self.mltype
-        Labelizer(self, mltype, count, classes).preview()
+        Labelizer(self, mltype, count, classes, include_background_tiles).preview()

--- a/pyveda/veda/api.py
+++ b/pyveda/veda/api.py
@@ -474,14 +474,16 @@ class VedaCollectionProxy(_VedaCollectionProxy):
         classes = self.classes
         mltype = self.mltype
         if return_flagged_tiles:
-            flagged_tiles = Labelizer(self, mltype, count, classes, include_background_tiles, return_flagged_tiles).clean()
-            return flagged_tiles
+            l = Labelizer(self, mltype, count, classes, include_background_tiles)
+            l.clean()
+            ft = iter(l.flagged_tiles)
+            return ft
         else:
-            Labelizer(self, mltype, count, classes, include_background_tiles, return_flagged_tiles).clean()
+            Labelizer(self, mltype, count, classes, include_background_tiles).clean()
 
 
 
-    def preview(self, count=10, include_background_tiles=True, return_flagged_tiles=False):
+    def preview(self, count=10, include_background_tiles=True):
         """
         Page through VedaCollection data and flag bad data.
         Params:

--- a/pyveda/veda/api.py
+++ b/pyveda/veda/api.py
@@ -488,4 +488,4 @@ class VedaCollectionProxy(_VedaCollectionProxy):
         """
         classes = self.classes
         mltype = self.mltype
-        Labelizer(self, mltype, count, classes, include_background_tiles, return_flagged_tiles).preview()
+        Labelizer(self, mltype, count, classes, include_background_tiles).preview()

--- a/pyveda/veda/api.py
+++ b/pyveda/veda/api.py
@@ -465,7 +465,7 @@ class VedaCollectionProxy(_VedaCollectionProxy):
     def __geo_interface__(self):
         return box(*self.bounds).__geo_interface__
 
-    def clean(self, count=None):
+    def clean(self, count=None, include_background_tiles=True):
         """
         Page through VedaCollection data and flag bad data.
         Params:
@@ -473,7 +473,7 @@ class VedaCollectionProxy(_VedaCollectionProxy):
         """
         classes = self.classes
         mltype = self.mltype
-        Labelizer(self, mltype, count, classes).clean()
+        Labelizer(self, mltype, count, classes, include_background_tiles).clean()
 
     def preview(self, count=10):
         """

--- a/pyveda/veda/api.py
+++ b/pyveda/veda/api.py
@@ -465,23 +465,20 @@ class VedaCollectionProxy(_VedaCollectionProxy):
     def __geo_interface__(self):
         return box(*self.bounds).__geo_interface__
 
-    def clean(self, count=None, include_background_tiles=True, return_flagged_tiles=False):
+    def clean(self, count=None, include_background_tiles=True):
         """
         Page through VedaCollection data and flag bad data.
         Params:
-            count: the number of tiles to clean
+            count (int): the number of tiles to clean
+            include_background_tiles (bool): include tiles that do not have labels on them
+        Returns:
+            l: a Labelizer() object
         """
         classes = self.classes
         mltype = self.mltype
-        if return_flagged_tiles:
-            l = Labelizer(self, mltype, count, classes, include_background_tiles)
-            l.clean()
-            ft = iter(l.flagged_tiles)
-            return ft
-        else:
-            Labelizer(self, mltype, count, classes, include_background_tiles).clean()
-
-
+        l = Labelizer(self, mltype, count, classes, include_background_tiles)
+        l.clean()
+        return l
 
     def preview(self, count=10, include_background_tiles=True):
         """

--- a/pyveda/vv/labelizer.py
+++ b/pyveda/vv/labelizer.py
@@ -28,7 +28,7 @@ from pyveda.vedaset import stream, store
 from pyveda import veda
 
 class Labelizer():
-    def __init__(self, vset, mltype, count, classes):
+    def __init__(self, vset, mltype, count, classes, include_background_tiles):
         """
           Labelizer will page through image/labels and allow users to remove/change data or labels from a VedaBase or VedaStream
           Params:
@@ -56,6 +56,7 @@ class Labelizer():
         self.classes = classes
         self.labels = self._create_labels()
         self.flagged_tiles = []
+        self.include_background_tiles = include_background_tiles
 
     def _get_next(self):
         self.index += 1

--- a/pyveda/vv/labelizer.py
+++ b/pyveda/vv/labelizer.py
@@ -64,6 +64,13 @@ class Labelizer():
         self.image = self._create_images()
         self.labels = self._create_labels()
 
+    def _check_for_background_tile(self):
+        lbl = self._create_labels()
+        if len(lbl) == 0:
+            return False
+        else:
+            return True
+
     def _create_images(self):
         """
         Creates image tiles from a datapoint

--- a/pyveda/vv/labelizer.py
+++ b/pyveda/vv/labelizer.py
@@ -154,6 +154,7 @@ class Labelizer():
             self.index += 1
             self._get_next()
         elif b.description == 'No':
+            self.index += 1
             self.flagged_tiles.append(self.datapoint)
             self._get_next()
         elif b.description == 'Exit':

--- a/pyveda/vv/labelizer.py
+++ b/pyveda/vv/labelizer.py
@@ -78,17 +78,16 @@ class Labelizer():
         lbl = self._create_labels()
         if self.mltype == 'object_detection' or self.mltype == 'segmentation':
             for i, shp in enumerate(lbl):
-                print(shp)
                 if len(shp) is not 0:
                     return True
-                    break
             else:
                 return False
-
         if self.mltype == 'classification':
-            print('hi')
-            #TODO: add conditionals for segmentation
-            # self._display_classification()
+            for i, shp in enumerate(lbl):
+                if shp != 0:
+                    return True
+            else:
+                return False
 
     def _create_images(self):
         """

--- a/pyveda/vv/labelizer.py
+++ b/pyveda/vv/labelizer.py
@@ -61,8 +61,15 @@ class Labelizer():
     def _get_next(self):
         self.index += 1
         self.datapoint = self.vedaset[self.index]
-        self.image = self._create_images()
-        self.labels = self._create_labels()
+        if include_background_tiles:
+            self.image = self._create_images()
+            self.labels = self._create_labels()
+        else:
+            if self._check_for_background_tile():
+                self.image = self._create_images()
+                self.labels = self._create_labels()
+            else:
+                self._get_next()
 
     def _check_for_background_tile(self):
         lbl = self._create_labels()

--- a/pyveda/vv/labelizer.py
+++ b/pyveda/vv/labelizer.py
@@ -53,9 +53,9 @@ class Labelizer():
         self.mltype = mltype
         self.classes = classes
         self.flagged_tiles = []
+        self.iflagged_tiles = []
         self.include_background_tiles = include_background_tiles
         self._get_next()  #create images, labels, and datapoint
-        self.return_flagged_tiles = return_flagged_tiles
 
 
     def _get_next(self):
@@ -174,20 +174,17 @@ class Labelizer():
         """
         try:
             if b.description == 'Keep':
-                self.datapoint = next(self.flagged_tiles)
+                self.datapoint = next(self.iflagged_tiles)
                 self.image = self._create_images()
                 self.labels = self._create_labels()
             elif b.description == 'Remove':
                 self.datapoint.remove() ##only works for VCP, currently
-                self.datapoint = next(self.flagged_tiles)
+                self.datapoint = next(self.iflagged_tiles)
                 self.image = self._create_images()
                 self.labels = self._create_labels()
             self.clean_flags()
         except StopIteration:
             print("All flagged tiles have been cleaned.")
-            # if self.return_flagged_tiles:
-            #     print('returning')
-            #     return self.flagged_tiles
 
     def _recolor_images(self):
         img = self.image.astype('float32')
@@ -323,8 +320,8 @@ class Labelizer():
         else:
             try:
                 print("You've flagged %0.f bad tiles. Review them now" %len(self.flagged_tiles))
-                self.flagged_tiles = iter(self.flagged_tiles)
-                self.datapoint = next(self.flagged_tiles)
+                self.iflagged_tiles = iter(self.flagged_tiles)
+                self.datapoint = next(self.iflagged_tiles)
                 self.image = self._create_images()
                 self.labels = self._create_labels()
                 self.clean_flags()

--- a/pyveda/vv/labelizer.py
+++ b/pyveda/vv/labelizer.py
@@ -60,7 +60,7 @@ class Labelizer():
 
 
     def _get_next(self):
-        self.index += 1
+        # self.index += 1
         self.datapoint = self.vedaset[self.index]
         if self.include_background_tiles:
             self.image = self._create_images()
@@ -74,7 +74,6 @@ class Labelizer():
                 self._get_next()
 
     def _check_for_background_tile(self):
-        ##CURRENT ISSUES: very slow, does not check for first tile
         lbl = self._create_labels()
         if self.mltype == 'object_detection' or self.mltype == 'segmentation':
             for i, shp in enumerate(lbl):

--- a/pyveda/vv/labelizer.py
+++ b/pyveda/vv/labelizer.py
@@ -342,3 +342,13 @@ class Labelizer():
                 self._display_segmentation(title=False)
             plt.show()
             self._get_next()
+
+    def return_flagged_tiles(self, return_list):
+        'Returns an iterator or list of tiles flagged with vcp'
+        if len(list(self.flagged_tiles)) == 0:
+            return 'No tiles flagged.'
+        else:
+            if return_list:
+                return(list(self.flagged_tiles))
+            else:
+                return(self.flagged_tiles)

--- a/pyveda/vv/labelizer.py
+++ b/pyveda/vv/labelizer.py
@@ -51,16 +51,13 @@ class Labelizer():
                 self.count = len(self.vedaset)
         self.index = 0
         self.mltype = mltype
-        self.datapoint = self.vedaset[self.index]
-        self.image = self._create_images()
         self.classes = classes
-        self.labels = self._create_labels()
         self.flagged_tiles = []
         self.include_background_tiles = include_background_tiles
+        self._get_next()  #create images, labels, and datapoint
 
 
     def _get_next(self):
-        # self.index += 1
         self.datapoint = self.vedaset[self.index]
         if self.include_background_tiles:
             self.image = self._create_images()

--- a/pyveda/vv/labelizer.py
+++ b/pyveda/vv/labelizer.py
@@ -28,7 +28,7 @@ from pyveda.vedaset import stream, store
 from pyveda import veda
 
 class Labelizer():
-    def __init__(self, vset, mltype, count, classes, include_background_tiles):
+    def __init__(self, vset, mltype, count, classes, include_background_tiles, return_flagged_tiles):
         """
           Labelizer will page through image/labels and allow users to remove/change data or labels from a VedaBase or VedaStream
           Params:
@@ -55,6 +55,7 @@ class Labelizer():
         self.flagged_tiles = []
         self.include_background_tiles = include_background_tiles
         self._get_next()  #create images, labels, and datapoint
+        self.return_flagged_tiles = return_flagged_tiles
 
 
     def _get_next(self):
@@ -183,6 +184,8 @@ class Labelizer():
             self.clean_flags()
         except StopIteration:
             print("All flagged tiles have been cleaned.")
+            if self.return_flagged_tiles:
+                return self.flagged_tiles
 
     def _recolor_images(self):
         img = self.image.astype('float32')
@@ -343,12 +346,9 @@ class Labelizer():
             plt.show()
             self._get_next()
 
-    def return_flagged_tiles(self, return_list):
-        'Returns an iterator or list of tiles flagged with vcp'
-        if len(list(self.flagged_tiles)) == 0:
-            return 'No tiles flagged.'
-        else:
-            if return_list:
-                return(list(self.flagged_tiles))
-            else:
-                return(self.flagged_tiles)
+    # def _return_flagged_tiles(self):
+    #     'Returns an iterator or list of tiles flagged with vcp'
+    #     if len(list(self.flagged_tiles)) == 0:
+    #         return 'No tiles flagged.'
+    #     else:
+    #         return(self.flagged_tiles)

--- a/pyveda/vv/labelizer.py
+++ b/pyveda/vv/labelizer.py
@@ -28,7 +28,7 @@ from pyveda.vedaset import stream, store
 from pyveda import veda
 
 class Labelizer():
-    def __init__(self, vset, mltype, count, classes, include_background_tiles, return_flagged_tiles):
+    def __init__(self, vset, mltype, count, classes, include_background_tiles):
         """
           Labelizer will page through image/labels and allow users to remove/change data or labels from a VedaBase or VedaStream
           Params:
@@ -185,8 +185,9 @@ class Labelizer():
             self.clean_flags()
         except StopIteration:
             print("All flagged tiles have been cleaned.")
-            if self.return_flagged_tiles:
-                return self.flagged_tiles
+            # if self.return_flagged_tiles:
+            #     print('returning')
+            #     return self.flagged_tiles
 
     def _recolor_images(self):
         img = self.image.astype('float32')
@@ -346,10 +347,3 @@ class Labelizer():
                 self._display_segmentation(title=False)
             plt.show()
             self._get_next()
-
-    # def _return_flagged_tiles(self):
-    #     'Returns an iterator or list of tiles flagged with vcp'
-    #     if len(list(self.flagged_tiles)) == 0:
-    #         return 'No tiles flagged.'
-    #     else:
-    #         return(self.flagged_tiles)

--- a/pyveda/vv/labelizer.py
+++ b/pyveda/vv/labelizer.py
@@ -58,25 +58,37 @@ class Labelizer():
         self.flagged_tiles = []
         self.include_background_tiles = include_background_tiles
 
+
     def _get_next(self):
         self.index += 1
         self.datapoint = self.vedaset[self.index]
-        if include_background_tiles:
+        if self.include_background_tiles:
             self.image = self._create_images()
             self.labels = self._create_labels()
         else:
-            if self._check_for_background_tile():
+            _check_for_background_tile = self._check_for_background_tile()
+            if _check_for_background_tile:
                 self.image = self._create_images()
                 self.labels = self._create_labels()
             else:
                 self._get_next()
 
     def _check_for_background_tile(self):
+        ##CURRENT ISSUES: very slow, does not check for first tile
         lbl = self._create_labels()
-        if len(lbl) == 0:
-            return False
-        else:
-            return True
+        if self.mltype == 'object_detection' or self.mltype == 'segmentation':
+            for i, shp in enumerate(lbl):
+                print(shp)
+                if len(shp) is not 0:
+                    return True
+                    break
+            else:
+                return False
+
+        if self.mltype == 'classification':
+            print('hi')
+            #TODO: add conditionals for segmentation
+            # self._display_classification()
 
     def _create_images(self):
         """


### PR DESCRIPTION
What does this PR do?
---------------------
This PR adds  the `include_background_tiles=True` param to Labelizer, so the user has the option to preview or clean with or without background tiles. This PR also makes tiles flagged during the cleaning process accessible as a list via:

```
vc = pv.from_id(id)
vv = vc.clean(...)
flagged_tiles = vv.flagged_tiles
```
-

What steps, if any, do reviewers need to take to set up their environments to test this properly?
---------------------
none
-

Acceptance criteria
---------------------
none
-

Known issues
---------------------
none
-

:white_check_mark: Checklist
---------------------

- [x ] No additional work is in process. This PR should be ready for merge right now.
- [ ] Tests are included
- [x ] There is at least one assignee
