### PR TITLE
Mlt 253 pyveda

### DIFF
--- a/pyveda/models/main.py
+++ b/pyveda/models/main.py
@@ -136,8 +136,6 @@ class Model(object):
             "bounds": bounds,
             "classes": self.classes,
             "channels_last": str(self.channels_last)
-            # "weights_file_name" = self.weights_file_name,
-            # "model_file_name" = self.model_file_name
         }
         if self.channels_last == 'true':
             meta["imshape"] = self.imshape[::-1]
@@ -216,9 +214,9 @@ class Model(object):
           "library": library,
           "location": kwargs.get("location", {}),
           "training_set": vcp_id,
-          "channels_last": self.channels_last
-          # "weights_file_name" = self.weights_file_name,
-          # "model_file_name" = self.model_file_name
+          "channels_last": self.channels_last,
+          "weights_file_name" = self.weights_file_name,
+          "model_file_name" = self.model_file_name
         }
         meta.update(overrides)
         return meta

--- a/pyveda/models/main.py
+++ b/pyveda/models/main.py
@@ -216,8 +216,8 @@ class Model(object):
           "library": library,
           "location": kwargs.get("location", {}),
           "training_set": vcp_id,
-          "channels_last": self.channels_last
-          "weights_file_name" = self.weights_file_name
+          "channels_last": self.channels_last,
+          "weights_file_name" = self.weights_file_name,
           "model_file_name" = self.model_file_name
         }
         meta.update(overrides)

--- a/pyveda/models/main.py
+++ b/pyveda/models/main.py
@@ -135,8 +135,8 @@ class Model(object):
             "public": False,
             "bounds": bounds,
             "classes": self.classes,
-            "channels_last": str(self.channels_last)
-            "weights_file_name" = self.weights_file_name
+            "channels_last": str(self.channels_last),
+            "weights_file_name" = self.weights_file_name,
             "model_file_name" = self.model_file_name
         }
         if self.channels_last == 'true':

--- a/pyveda/models/main.py
+++ b/pyveda/models/main.py
@@ -215,8 +215,8 @@ class Model(object):
           "location": kwargs.get("location", {}),
           "training_set": vcp_id,
           "channels_last": self.channels_last,
-          "weights_file_name" = self.weights_file_name,
-          "model_file_name" = self.model_file_name
+          "weights_file_name": self.weights_file_name,
+          "model_file_name": self.model_file_name
         }
         meta.update(overrides)
         return meta

--- a/pyveda/models/main.py
+++ b/pyveda/models/main.py
@@ -135,9 +135,9 @@ class Model(object):
             "public": False,
             "bounds": bounds,
             "classes": self.classes,
-            "channels_last": str(self.channels_last),
-            "weights_file_name" = self.weights_file_name,
-            "model_file_name" = self.model_file_name
+            "channels_last": str(self.channels_last)
+            # "weights_file_name" = self.weights_file_name,
+            # "model_file_name" = self.model_file_name
         }
         if self.channels_last == 'true':
             meta["imshape"] = self.imshape[::-1]
@@ -216,9 +216,9 @@ class Model(object):
           "library": library,
           "location": kwargs.get("location", {}),
           "training_set": vcp_id,
-          "channels_last": self.channels_last,
-          "weights_file_name" = self.weights_file_name,
-          "model_file_name" = self.model_file_name
+          "channels_last": self.channels_last
+          # "weights_file_name" = self.weights_file_name,
+          # "model_file_name" = self.model_file_name
         }
         meta.update(overrides)
         return meta


### PR DESCRIPTION
What does this PR do?
---------------------

- Allows flexibility for the user to name the weights or model, and pass these names as strings to the qworker so it can initialize the model in `Veda` (PR-253). 

What steps, if any, do reviewers need to take to set up their environments to test this properly?
---------------------

- pull down veda MLT-253 and re-build the warmer by running `npm run build-qworker`

Acceptance criteria
---------------------

- model is initialized 
- model makes predictions 

Known issues
---------------------

- does not work for models with custom layers or custom loss functions 

:white_check_mark: Checklist
---------------------

- [ ] No additional work is in process. This PR should be ready for merge right now.
- [ ] Tests are included
- [ X] There is at least one assignee

Attn @msmith303
