### PR TITLE
add filename error if vedabase is not created with .h5

### DIFF
--- a/pyveda/vedaset/store/vedabase.py
+++ b/pyveda/vedaset/store/vedabase.py
@@ -102,6 +102,9 @@ class H5DataBase(BaseDataSet):
     _frozen = ("mltype", "image_shape", "image_dtype", "classes")
 
     def __init__(self, fname, title="SBWM", overwrite=False, mode="a", **kwargs):
+
+        if not fname.endswith('.h5'):
+            raise ValueError("filename must end in .h5")
         exists = False
         if os.path.exists(fname):
             if overwrite:


### PR DESCRIPTION
What does this PR do?
---------------------

- checks that the filename for the creation of a VedaBase has .h5 extension, and errors if not, to prevent vague errors form pytables later 

What steps, if any, do reviewers need to take to set up their environments to test this properly?
---------------------

- NA

Acceptance criteria
---------------------

- does not allow a VedaBase to be created if file extension is not .h5

Known issues
---------------------

-

:white_check_mark: Checklist
---------------------

- [X ] No additional work is in process. This PR should be ready for merge right now.
- [ ] Tests are included
- [X ] There is at least one assignee

Attn @msmith303
