### PR TITLE
Mlt 270 preview method

### DIFF
--- a/pyveda/vedaset/store/vedabase.py
+++ b/pyveda/vedaset/store/vedabase.py
@@ -91,6 +91,15 @@ class H5SampleArray(BaseSampleArray):
         mltype = self._vset.mltype
         Labelizer(self, mltype, count, classes, include_background_tiles).clean()
 
+    def preview(self, count=10, include_background_tiles=True):
+        """
+        Page through VedaCollection data and flag bad data.
+        Params:
+            count: the number of tiles to clean
+        """
+        classes = self._vset.classes
+        mltype = self._vset.mltype
+        Labelizer(self, mltype, count, classes, include_background_tiles).preview()
 
 class H5DataBase(BaseDataSet):
     """

--- a/pyveda/vedaset/veda/api.py
+++ b/pyveda/vedaset/veda/api.py
@@ -477,7 +477,7 @@ class VedaCollectionProxy(_VedaCollectionProxy):
         """
         classes = self.classes
         mltype = self.mltype
-        l = Labelizer(self, mltype, count, classes, include_background_tiles)
+        l = Labelizer(self, mltype=mltype, count=count, classes=classes, include_background_tiles=include_background_tiles)
         l.clean()
         return l
 
@@ -485,15 +485,12 @@ class VedaCollectionProxy(_VedaCollectionProxy):
         """
         Page through VedaCollection data and flag bad data.
         Params:
-            count: the number of tiles to clean
+            count: the number of tiles to preview
         """
         classes = self.classes
         mltype = self.mltype
-        Labelizer(self, mltype, count, classes, include_background_tiles).preview()
+        Labelizer(self,  mltype=mltype, count=count, classes=classes, include_background_tiles=include_background_tiles).preview()
 
     def remove_black_tiles(self):
-        include_background_tiles=True
-        classes = self.classes
-        mltype = self.mltype
         count = None
-        Labelizer(self, mltype, count, classes, include_background_tiles).remove_black_tiles()
+        Labelizer(self, count=count).remove_black_tiles()

--- a/pyveda/vedaset/veda/api.py
+++ b/pyveda/vedaset/veda/api.py
@@ -490,3 +490,10 @@ class VedaCollectionProxy(_VedaCollectionProxy):
         classes = self.classes
         mltype = self.mltype
         Labelizer(self, mltype, count, classes, include_background_tiles).preview()
+
+    def remove_black_tiles(self):
+        include_background_tiles=True
+        classes = self.classes
+        mltype = self.mltype
+        count = None
+        Labelizer(self, mltype, count, classes, include_background_tiles).remove_black_tiles()

--- a/pyveda/vv/labelizer.py
+++ b/pyveda/vv/labelizer.py
@@ -369,5 +369,4 @@ class Labelizer():
                 if isinstance(self.mltype, abstract.InstanceSegmentationType):
                     self._display_segmentation(title=False)
             plt.show()
-            self.index += 1
             self._get_next()

--- a/pyveda/vv/labelizer.py
+++ b/pyveda/vv/labelizer.py
@@ -325,8 +325,6 @@ class Labelizer():
                     self._display_obj_detection()
                 if isinstance(self.mltype, abstract.SegmentationType):
                     self._display_segmentation()
-
-
         else:
             try:
                 print("You've flagged %0.f bad tiles. Review them now" %len(self.flagged_tiles))
@@ -346,11 +344,19 @@ class Labelizer():
         display(HBox(buttons))
         for c in range(0, self.count):
             self._display_image()
-            if self.mltype == 'object_detection':
-                self._display_obj_detection(title=False)
-            if self.mltype == 'classification':
-                self._display_classification(title=False)
-            if self.mltype == 'segmentation':
-                self._display_segmentation(title=False)
+            if isinstance(self.vedaset, veda.api.VedaCollectionProxy):
+                if self.mltype == 'object_detection':
+                    self._display_obj_detection(title=False)
+                if self.mltype == 'classification':
+                    self._display_classification(title=False)
+                if self.mltype == 'segmentation':
+                    self._display_segmentation(title=False)
+            else:
+                if isinstance(self.mltype, abstract.BinaryClassificationType):
+                    self._display_classification(title=False)
+                if isinstance(self.mltype, abstract.ObjectDetectionType):
+                    self._display_obj_detection(title=False)
+                if isinstance(self.mltype, abstract.SegmentationType):
+                    self._display_segmentation(title=False)
             plt.show()
             self._get_next()

--- a/pyveda/vv/labelizer.py
+++ b/pyveda/vv/labelizer.py
@@ -288,12 +288,20 @@ class Labelizer():
             b.on_click(self._handle_flag_buttons)
         if self.datapoint is not None:
             self._display_image()
-            if self.mltype == 'object_detection':
-                self._display_obj_detection()
-            if self.mltype == 'classification':
-                self._display_classification()
-            if self.mltype == 'segmentation':
-                self._display_segmentation()
+            if isinstance(self.vedaset, veda.api.VedaCollectionProxy):
+                if self.mltype == 'object_detection':
+                    self._display_obj_detection()
+                if self.mltype == 'classification':
+                    self._display_classification()
+                if self.mltype == 'segmentation':
+                    self._display_segmentation()
+            else:
+                if isinstance(self.mltype, abstract.BinaryClassificationType):
+                    self._display_classification()
+                if isinstance(self.mltype, abstract.ObjectDetectionType):
+                    self._display_obj_detection()
+                if isinstance(self.mltype, abstract.InstanceSegmentationType):
+                    self._display_segmentation()
             print('Do you want to remove this tile?')
             display(HBox(buttons))
 

--- a/pyveda/vv/labelizer.py
+++ b/pyveda/vv/labelizer.py
@@ -237,9 +237,15 @@ class Labelizer():
             if binary_class != 0:
                 positive_classes.append(self.classes[i])
         if title==True:
-            plt.title('Does this tile contain: %s?' % ', '.join(positive_classes), fontsize=14)
+            if positive_classes:
+                plt.title('Does this tile contain: %s?' % ', '.join(positive_classes), fontsize=14)
+            else:
+                plt.title('Does this tile contain: no labeled objects?', fontsize=14)
         else:
-            plt.title('Tile contains: %s' % ', '.join(positive_classes), fontsize=14)
+            if positive_classes:
+                plt.title('Tile contains: %s' % ', '.join(positive_classes), fontsize=14)
+            else:
+                plt.title('Tile contains: no labeled objects', fontsize=14)
 
     def _display_segmentation(self, title=True):
         """

--- a/pyveda/vv/labelizer.py
+++ b/pyveda/vv/labelizer.py
@@ -49,7 +49,7 @@ class Labelizer():
                 self.count = self.vedaset.count
             except:
                 self.count = len(self.vedaset)
-        self.index = 0
+        self.index = None
         self.mltype = mltype
         self.classes = classes
         self.flagged_tiles = []
@@ -59,6 +59,10 @@ class Labelizer():
 
 
     def _get_next(self):
+        if self.index is not None:
+            self.index +=1
+        else:
+            self.index = 0
         self.datapoint = self.vedaset[self.index]
         if self.include_background_tiles:
             self.image = self._create_images()
@@ -151,10 +155,8 @@ class Labelizer():
         Callback and handling of widget buttons.
         """
         if b.description == 'Yes':
-            self.index += 1
             self._get_next()
         elif b.description == 'No':
-            self.index += 1
             self.flagged_tiles.append(self.datapoint)
             self._get_next()
         elif b.description == 'Exit':
@@ -323,8 +325,8 @@ class Labelizer():
                     self._display_classification()
                 if isinstance(self.mltype, abstract.ObjectDetectionType):
                     self._display_obj_detection()
-                # if isinstance(self.mltype, abstract.SegmentationType):
-                #     self._display_segmentation()
+                if isinstance(self.mltype, abstract.InstanceSegmentationType):
+                    self._display_segmentation()
         else:
             try:
                 print("You've flagged %0.f bad tiles. Review them now" %len(self.flagged_tiles))
@@ -356,7 +358,8 @@ class Labelizer():
                     self._display_classification(title=False)
                 if isinstance(self.mltype, abstract.ObjectDetectionType):
                     self._display_obj_detection(title=False)
-                # if isinstance(self.mltype, abstract.SegmentationType):
-                #     self._display_segmentation(title=False)
+                if isinstance(self.mltype, abstract.InstanceSegmentationType):
+                    self._display_segmentation(title=False)
             plt.show()
+            self.index += 1
             self._get_next()

--- a/pyveda/vv/labelizer.py
+++ b/pyveda/vv/labelizer.py
@@ -379,8 +379,7 @@ class Labelizer():
 
     def remove_black_tiles(self):
         for c in range(self.count):
-            print(np.amax(self.image))
-            print(self.datapoint.id)
             if np.amax(self.image) == 0:
                 self.datapoint.remove()
+                print('removing tile %s' % self.datapoint.id)
             self._get_next()

--- a/pyveda/vv/labelizer.py
+++ b/pyveda/vv/labelizer.py
@@ -323,8 +323,8 @@ class Labelizer():
                     self._display_classification()
                 if isinstance(self.mltype, abstract.ObjectDetectionType):
                     self._display_obj_detection()
-                if isinstance(self.mltype, abstract.SegmentationType):
-                    self._display_segmentation()
+                # if isinstance(self.mltype, abstract.SegmentationType):
+                #     self._display_segmentation()
         else:
             try:
                 print("You've flagged %0.f bad tiles. Review them now" %len(self.flagged_tiles))
@@ -356,7 +356,7 @@ class Labelizer():
                     self._display_classification(title=False)
                 if isinstance(self.mltype, abstract.ObjectDetectionType):
                     self._display_obj_detection(title=False)
-                if isinstance(self.mltype, abstract.SegmentationType):
-                    self._display_segmentation(title=False)
+                # if isinstance(self.mltype, abstract.SegmentationType):
+                #     self._display_segmentation(title=False)
             plt.show()
             self._get_next()

--- a/pyveda/vv/labelizer.py
+++ b/pyveda/vv/labelizer.py
@@ -28,7 +28,7 @@ from pyveda.vedaset import stream, store
 from pyveda.vedaset import veda, abstract
 
 class Labelizer():
-    def __init__(self, vset, mltype, count, classes, include_background_tiles):
+    def __init__(self, vset, mltype=None, count=None, classes=None, include_background_tiles=None):
         """
           Labelizer will page through image/labels and allow users to remove/change data or labels from a VedaBase or VedaStream
           Params:

--- a/pyveda/vv/labelizer.py
+++ b/pyveda/vv/labelizer.py
@@ -376,3 +376,11 @@ class Labelizer():
                     self._display_segmentation(title=False)
             plt.show()
             self._get_next()
+
+    def remove_black_tiles(self):
+        for c in range(self.count):
+            print(np.amax(self.image))
+            print(self.datapoint.id)
+            if np.amax(self.image) == 0:
+                self.datapoint.remove()
+            self._get_next()


### PR DESCRIPTION
What does this PR do?
---------------------

- adds the preview method to vedabase and vedastream
- fixes indexing issues with vedabase and vedastream
- adds a remove black tiles method to vcp
- makes certain labelizer args optional

Known issues
---------------------
- this PR does not address the repeat tiles problem with vcp, however I want to get it in so we can use the new preview stuff in the chipping notebook series. 

:white_check_mark: Checklist
---------------------

- [x] No additional work is in process. This PR should be ready for merge right now.
- [ ] Tests are included
- [x] There is at least one assignee

Attn @msmith303
