### PR TITLE
Mlt 284 vcp iter

### DIFF
--- a/pyveda/vedaset/store/vedabase.py
+++ b/pyveda/vedaset/store/vedabase.py
@@ -8,7 +8,7 @@ from pyveda.exceptions import LabelNotSupported, FrameworkNotSupported
 from pyveda.vedaset.base import BaseDataSet, BaseSampleArray
 from pyveda.vedaset.interface import SerializedVariableArray, PartitionedIndexArray, ArrayTransformPlugin
 from pyveda.frameworks.batch_generator import VedaStoreGenerator
-from pyveda.vv.labelizer import Labelizer
+from pyveda import vv
 from pyveda.utils import update_options
 
 
@@ -89,17 +89,12 @@ class H5SampleArray(BaseSampleArray):
         """
         classes = self._vset.classes
         mltype = self._vset.mltype
-        Labelizer(self, mltype, count, classes, include_background_tiles).clean()
+        vv.labelizer.Labelizer(self, mltype, count, classes, include_background_tiles).clean()
 
     def preview(self, count=10, include_background_tiles=True):
-        """
-        Page through VedaCollection data and flag bad data.
-        Params:
-            count: the number of tiles to clean
-        """
         classes = self._vset.classes
         mltype = self._vset.mltype
-        Labelizer(self, mltype, count, classes, include_background_tiles).preview()
+        vv.labelizer.Labelizer(self, mltype, count, classes, include_background_tiles).preview()
 
 class H5DataBase(BaseDataSet):
     """

--- a/pyveda/vedaset/stream/vedastream.py
+++ b/pyveda/vedaset/stream/vedastream.py
@@ -11,7 +11,7 @@ from pyveda.io.remote.client import HTTPVedaClient
 from pyveda.vedaset.base import BaseSampleArray, BaseDataSet
 from pyveda.vedaset.interface import BaseVariableArray, ArrayTransformPlugin
 from pyveda.frameworks.batch_generator import VedaStreamGenerator
-#from pyveda.vv.labelizer import Labelizer
+from pyveda.vv.labelizer import Labelizer
 
 
 class BufferedVariableArray(ArrayTransformPlugin):
@@ -122,6 +122,11 @@ class BufferedSampleArray(BaseSampleArray):
         classes = self._vset.classes
         mltype = self._vset.mltype
         Labelizer(self, mltype, count, classes).clean()
+
+    def preview(self, count=10, include_background_tiles=True):
+        classes = self._vset.classes
+        mltype = self._vset.mltype
+        Labelizer(self, mltype, count, classes, include_background_tiles).preview()
 
 
 class BufferedDataStream(BaseDataSet):
@@ -270,5 +275,3 @@ class BufferedDataStream(BaseDataSet):
 
     def __len__(self):
         return self.count
-
-

--- a/pyveda/vedaset/veda/api.py
+++ b/pyveda/vedaset/veda/api.py
@@ -402,17 +402,26 @@ class VedaCollectionProxy(_VedaCollectionProxy):
         doc['properties']['id'] = _id
         return cls.from_doc(doc)
 
+    # def __iter__(self):
+    #     self.n = 0
+    #     return self
+    #
+    # def __next__(self):
+    #     if self.n <= self.count:
+    #         dp = self.fetch_samples_from_slice(self.n, num_points=1)
+    #         self.n += 1
+    #         return dp[0]
+    #     else:
+    #         raise StopIteration
+
     def __iter__(self):
-        self.n = 0
+        self._ids = self.gen_sample_ids(get_urls=False)
         return self
 
     def __next__(self):
-        if self.n <= self.count:
-            dp = self.fetch_samples_from_slice(self.n, num_points=1)
-            self.n += 1
-            return dp[0]
-        else:
-            raise StopIteration
+        id = next(self._ids)
+        dp = self.fetch_sample_from_id(id)
+        return dp
 
     def __getitem__(self, slc):
         """ Enable slicing of the data by index/slice """

--- a/pyveda/vedaset/veda/api.py
+++ b/pyveda/vedaset/veda/api.py
@@ -402,18 +402,6 @@ class VedaCollectionProxy(_VedaCollectionProxy):
         doc['properties']['id'] = _id
         return cls.from_doc(doc)
 
-    # def __iter__(self):
-    #     self.n = 0
-    #     return self
-    #
-    # def __next__(self):
-    #     if self.n <= self.count:
-    #         dp = self.fetch_samples_from_slice(self.n, num_points=1)
-    #         self.n += 1
-    #         return dp[0]
-    #     else:
-    #         raise StopIteration
-
     def __iter__(self):
         self._ids = self.gen_sample_ids(get_urls=False)
         return self

--- a/pyveda/vv/labelizer.py
+++ b/pyveda/vv/labelizer.py
@@ -55,6 +55,9 @@ class Labelizer():
         self.flagged_tiles = []
         self.iflagged_tiles = []
         self.include_background_tiles = include_background_tiles
+        self.id = []
+        if isinstance(self.vedaset, veda.api.VedaCollectionProxy):
+            self.datapoint = iter(self.vedaset)
         self._get_next()  #create images, labels, and datapoint
 
 
@@ -63,7 +66,7 @@ class Labelizer():
             self.index +=1
         else:
             self.index = 0
-        self.datapoint = self.vedaset[self.index]
+        self.datapoint = self.vedaset[self.index] ###get next item in index
         if self.include_background_tiles:
             self.image = self._create_images()
             self.labels = self._create_labels()

--- a/pyveda/vv/labelizer.py
+++ b/pyveda/vv/labelizer.py
@@ -42,6 +42,8 @@ class Labelizer():
         assert has_plt, 'Labelizer requires matplotlib to be installed'
 
         self.vedaset = vset
+        if isinstance(self.vedaset, veda.api.VedaCollectionProxy):
+            self.vedaset = iter(self.vedaset)
         if count is not None:
             self.count = count
         else:
@@ -56,8 +58,6 @@ class Labelizer():
         self.iflagged_tiles = []
         self.include_background_tiles = include_background_tiles
         self.id = []
-        if isinstance(self.vedaset, veda.api.VedaCollectionProxy):
-            self.datapoint = iter(self.vedaset)
         self._get_next()  #create images, labels, and datapoint
 
 


### PR DESCRIPTION
What does this PR do?
---------------------

Previously, users were seeing repeat tiles on VCPs, and also having trouble actually iterating over VCPs, because of the way that iterator method was handling elasticsearch results from VS. This PR corrects this issue by fetching tiles from individual datapoint IDs instead of via slices/"indexes" directly from VS. 

What steps, if any, do reviewers need to take to set up their environments to test this properly?
---------------------
 - pull n go


Acceptance criteria
---------------------

-

Known issues
---------------------
- none


:white_check_mark: Checklist
---------------------
- [x] No additional work is in process. This PR should be ready for merge right now.
- [ ] Tests are included
- [x] There is at least one assignee

