### PR TITLE
FIX Update makefile to install pycurl correctly on macos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
 init:
 	git config core.hooksPath .githooks
+	if [ "$$(uname)" = "Darwin" ]; then \
+		PYCURL_SSL_LIBRARY=openssl LDFLAGS="-L/usr/local/opt/openssl/lib" CPPFLAGS="-I/usr/local/opt/openssl/include" pip install --no-cache-dir pycurl; \
+	fi
 	pip install -r requirements.txt


### PR DESCRIPTION
What does this PR do?
---------------------

- Installs pycurl by specifying the ssl backend before pip installing in order to avoid ssl error

What steps, if any, do reviewers need to take to set up their environments to test this properly?
---------------------

- Clone pyveda into a new directory
- Create/activate virtualenv
- Run `make` to setup pyveda

Acceptance criteria
---------------------

- `make` exits without error
- pyveda can run in the virtualenv, e.g. `python -c "import pyveda as pv; pv.config.set_dev(); print(pv.search())"` runs ok

Known issues
---------------------

- User may not have xcode dev tools installed, in which case openssl will be missing

:white_check_mark: Checklist
---------------------

- [x] No additional work is in process. This PR should be ready for merge right now.
- [ ] Tests are included
- [x] There is at least one assignee

Attn @msmith303
