### PR TITLE
FIX Enable pyveda to target Veda at localhost address

### DIFF
--- a/pyveda/auth.py
+++ b/pyveda/auth.py
@@ -48,7 +48,7 @@ class _Auth(object):
             self.gbdx_connection = gbdx_auth.get_session(kwargs.get('config_file'))
 
         # for local dev, cant use oauth2
-        if HOST == 'http://host.docker.internal:3002':
+        if not kwargs.get('oauth', True):
             self.gbdx_connection = localhost(self.gbdx_connection)
 
         def expire_token(r, *args, **kw):

--- a/pyveda/config.py
+++ b/pyveda/config.py
@@ -1,3 +1,4 @@
+import logging
 import os
 from pyveda.auth import Auth
 
@@ -59,8 +60,8 @@ class _Config:
         self._HOST = os.environ.get("SANDMAN_API", defhost)
         try:
             self._CONN = Auth().gbdx_connection
-        except:
-            pass
+        except Exception as err:
+            logging.error(f'Error creating connection: `{err}`')
 
     @property
     def HOST(self):
@@ -80,7 +81,8 @@ def set_dev():
     config._HOST = DEV
 
 def set_local():
-    config._HOST = LOCAL
+    config._CONN = Auth(oauth=False).gbdx_connection
+    config._HOST = os.environ.get('SANDMAN_API', LOCAL)
 
 def set_host(host):
     config._HOST = host


### PR DESCRIPTION
What does this PR do?
---------------------

- Right now, `pv.config.set_local()` only works within the sandbook container, since it sets the Veda host address to `http://host.docker.internal:3002`.
- This PR allows this behavior to be overridden by providing the `SANDMAN_API` environment variable **and** calling `pv.config.set_local()` (in order to disable oauth2)

What steps, if any, do reviewers need to take to set up their environments to test this properly?
---------------------

- Pull changes
- Run veda locally
- Set environment variable `SANDMAN_API=http://localhost:3002`

Acceptance criteria
---------------------

- The following lists vedasets:
```bash
$ SANDMAN_API=http://localhost:3002 python
> import pyveda as pv
> pv.config.set_local()
> pv.search()
```

Known issues
---------------------

- `pv.config.set_local()` still defaults to `https://host.docker.internal:3002`; if no one is using pyveda inside veda's sandbook container this is unnecessary

:white_check_mark: Checklist
---------------------

- [x] No additional work is in process. This PR should be ready for merge right now.
- [ ] Tests are included
- [x] There is at least one assignee

Attn @msmith303
